### PR TITLE
Attributes named like mysql reserved keywords will break flat catalog…

### DIFF
--- a/app/code/Magento/Catalog/Model/Indexer/Product/Flat/FlatTableBuilder.php
+++ b/app/code/Magento/Catalog/Model/Indexer/Product/Flat/FlatTableBuilder.php
@@ -365,7 +365,7 @@ class FlatTableBuilder
                         []
                     )->columns(
                         [$columnName => $this->_connection->getIfNullSql('ts.value', 't0.value')]
-                    )->where($attributeCode . ' IS NOT NULL');
+                    )->where('et.' . $attributeCode . ' IS NOT NULL');
                     if (!empty($changedIds)) {
                         $select->where($this->_connection->quoteInto('et.entity_id IN (?)', $changedIds));
                     }


### PR DESCRIPTION
… indexing

Having a product attribute named condition or some other mysql reserved keyword will result in an error while indexing flat catalog:

Ex: 

SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'condition IS NOT NULL)' at line 5, query was: UPDATE `catalog_product_flat_1_tmp_indexer` AS `et`
 LEFT JOIN `eav_attribute_option_value` AS `t0` ON t0.option_id = et.condition AND t0.store_id = 0
 LEFT JOIN `eav_attribute_option_value` AS `ts` ON ts.option_id = et.condition AND ts.store_id = 1
SET `et`.`condition_value` = IFNULL(ts.value, t0.value)
WHERE (condition IS NOT NULL)

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#<issue_number>: Issue title
2. ...

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
